### PR TITLE
Create bashrc_archer2

### DIFF
--- a/etc/bashrc_archer2
+++ b/etc/bashrc_archer2
@@ -1,0 +1,3 @@
+# .bashrc
+source $FOAM_INSTALL_DIR/etc/bashrc
+source $GCFOAM_DIR/ThirdParty/bashrc


### PR DESCRIPTION
Added the missing bashrc file, previously agreed, which is required by the archer2 module and for the wiki user guide to function as advertised.